### PR TITLE
Fix path in the end of render_builder_code method

### DIFF
--- a/src/cymple/internal/internal_renderer.py
+++ b/src/cymple/internal/internal_renderer.py
@@ -162,9 +162,9 @@ def render_builder_code():
         file.write(decorators_output)
         file.write(finale_output)
 
+    builder_path = os.path.join(pathlib.Path(__file__).parent.parent.resolve(), "builder.py")
     os.system(
-        f'autopep8 {pathlib.Path(__file__).parent.parent.resolve()}\\builder.py --in-place --max-line-length {MAX_LINE_LEN}')
-
+        f'autopep8 {builder_path} --in-place --max-line-length {MAX_LINE_LEN}')
 
 if __name__ == '__main__':
     render_builder_code()


### PR DESCRIPTION
In the end of the method, there is a call to os.system with the path:

{pathlib.Path(__file__).parent.parent.resolve()}\\builder.py

Which on MacOS yields an invalid path (the '\' concatenation is probably valid only for Windows OS).

Change needed: use os.path.join instead