### PR TITLE
fix: add `str` to type annotation for labels

### DIFF
--- a/src/cymple/builder.py
+++ b/src/cymple/builder.py
@@ -172,11 +172,11 @@ class Merge(Query):
 class Node(Query):
     """A class for representing a "NODE" clause."""
 
-    def node(self, labels: List[str] = None, ref_name: str = None, properties: dict = None):
+    def node(self, labels: List[str] | str = None, ref_name: str = None, properties: dict = None):
         """Concatenate a graph Node, which may be filtered using any label/s and/or property/properties.
 
         :param labels: The neo4j label (or list of labels) for that node, defaults to None
-        :type labels: List[str]
+        :type labels: List[str] | str
         :param ref_name: A reference name to be used later in the rest of the query, defaults to None
         :type ref_name: str
         :param properties: A dict representing the set of properties by which the nodes are filtered, defaults to None
@@ -214,11 +214,11 @@ class Node(Query):
 class NodeAfterMerge(Query):
     """A class for representing a "NODE AFTER MERGE" clause."""
 
-    def node(self, labels: List[str] = None, ref_name: str = None, properties: dict = None):
+    def node(self, labels: List[str] | str = None, ref_name: str = None, properties: dict = None):
         """Concatenate a graph Node, which may be filtered using any label/s and/or property/properties.
 
         :param labels: The neo4j label (or list of labels) for that node, defaults to None
-        :type labels: List[str]
+        :type labels: List[str] | str
         :param ref_name: A reference name to be used later in the rest of the query, defaults to None
         :type ref_name: str
         :param properties: A dict representing the set of properties by which the nodes are filtered, defaults to None

--- a/src/samples/basic.py
+++ b/src/samples/basic.py
@@ -4,7 +4,7 @@ from cymple.builder import QueryBuilder
 
 
 
-def get_all_nodes_by_label(labels: List[str], node_name: str = 'n'):
+def get_all_nodes_by_label(labels: List[str] | str, node_name: str = 'n'):
     return (QueryBuilder()
             .match()
             .node(labels=labels, ref_name=node_name)
@@ -12,7 +12,7 @@ def get_all_nodes_by_label(labels: List[str], node_name: str = 'n'):
             )
 
 
-def get_all_nodes_by_label_and_properties(labels: List[str], properties: Dict[str, Any], node_name: str = 'n'):
+def get_all_nodes_by_label_and_properties(labels: List[str] | str, properties: Dict[str, Any], node_name: str = 'n'):
     return (QueryBuilder()
             .match()
             .node(labels=labels, ref_name=node_name, properties=properties)
@@ -20,7 +20,7 @@ def get_all_nodes_by_label_and_properties(labels: List[str], properties: Dict[st
             )
 
 
-def get_all_paths(src_node_labels: List[str], dst_node_labels: List[str], relationship_type: str, path_name: str = 'p'):
+def get_all_paths(src_node_labels: List[str] | str, dst_node_labels: List[str] | str, relationship_type: str, path_name: str = 'p'):
     return (QueryBuilder()
             .match()
             .operator_start(operator='', ref_name=path_name)
@@ -32,7 +32,7 @@ def get_all_paths(src_node_labels: List[str], dst_node_labels: List[str], relati
             )
 
 
-def get_all_nodes_related_to_nodes(src_node_labels: List[str], dst_node_labels: List[str], relationship_type: str, dst_node_name: str = 'd'):
+def get_all_nodes_related_to_nodes(src_node_labels: List[str] | str, dst_node_labels: List[str] | str, relationship_type: str, dst_node_name: str = 'd'):
     return (QueryBuilder()
             .match()
             .node(labels=src_node_labels)
@@ -42,7 +42,7 @@ def get_all_nodes_related_to_nodes(src_node_labels: List[str], dst_node_labels: 
             )
 
 
-def get_all_nodes_related_by_fixed_num_of_hops(src_node_labels: List[str], dst_node_labels: List[str], num_hops: int, dst_node_name: str = 'd'):
+def get_all_nodes_related_by_fixed_num_of_hops(src_node_labels: List[str] | str, dst_node_labels: List[str] | str, num_hops: int, dst_node_name: str = 'd'):
     return (QueryBuilder()
             .match()
             .node(labels=src_node_labels)
@@ -52,7 +52,7 @@ def get_all_nodes_related_by_fixed_num_of_hops(src_node_labels: List[str], dst_n
             )
 
 
-def get_all_nodes_related_by_varying_num_of_hops(src_node_labels: List[str], dst_node_labels: List[str], min_hops: int, max_hops: int, dst_node_name: str = 'd'):
+def get_all_nodes_related_by_varying_num_of_hops(src_node_labels: List[str] | str, dst_node_labels: List[str] | str, min_hops: int, max_hops: int, dst_node_name: str = 'd'):
     return (QueryBuilder()
             .match()
             .node(labels=src_node_labels)
@@ -62,15 +62,15 @@ def get_all_nodes_related_by_varying_num_of_hops(src_node_labels: List[str], dst
             )
 
 
-def get_nodes_with_pagination(node_labels: List[str], node_name: str = 'n', offset: int = 0, limit: int = -1):
+def get_nodes_with_pagination(node_labels: List[str] | str, node_name: str = 'n', offset: int = 0, limit: int = -1):
     raise NotImplementedError()
 
 
-def create_node(node_labels: List[str]):
+def create_node(node_labels: List[str] | str):
     raise NotImplementedError()
 
 
-def merge_node(node_labels: List[str], properties: Dict[str, Any] = None):
+def merge_node(node_labels: List[str] | str, properties: Dict[str, Any] = None):
     return (QueryBuilder()
             .merge()
             .node(labels=node_labels, properties=properties)
@@ -81,8 +81,8 @@ def create_relationship(relationship_type: str):
     raise NotImplementedError()
 
 
-def merge_relationship(relationship_type: str, properties: Dict[str, Any] = None, src_node_labels: List[str] = None, 
-                        dst_node_labels: List[str] = None, src_node_properties: Dict[str, Any] = None, dst_node_properties: Dict[str, Any] = None):
+def merge_relationship(relationship_type: str, properties: Dict[str, Any] = None, src_node_labels: List[str] | str = None,
+                        dst_node_labels: List[str] | str = None, src_node_properties: Dict[str, Any] = None, dst_node_properties: Dict[str, Any] = None):
     return (QueryBuilder()
             .match()
             .node(labels=src_node_labels, properties=src_node_properties, ref_name='src')


### PR DESCRIPTION
Hey, thanks for this project! 
@MarJene and I are actively using this as of recently.
### Problem
Even though the `labels` argument can also be `str` type, the type annotation doesn't account for that.
### Solution
Change the type annotation for arguments where a `str` can also be passed.